### PR TITLE
prometheus-openziti-exporter: Add missing default image tag

### DIFF
--- a/charts/prometheus-openziti-exporter/Chart.yaml
+++ b/charts/prometheus-openziti-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.0.1
+appVersion: v0.0.2
 description: Prometheus exporter for Openziti
 name: prometheus-openziti-exporter
-version: 1.0.1
+version: 1.0.2
 icon: https://openziti.io/img/ziti-logo-dark.svg
 home: https://github.com/enthus-it/openziti_exporter
 sources:
@@ -11,8 +11,8 @@ keywords:
   - openziti
   - prometheus
 maintainers:
-- email: alexander.waal@enthus.de
-  name: Alexander Waal
+- name: AlexanderENTH
+  email: alexander.waal@enthus.de
 - name: mjtrangoni
   email: mjtrangoni@gmail.com
 type: application

--- a/charts/prometheus-openziti-exporter/templates/deployment.yaml
+++ b/charts/prometheus-openziti-exporter/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           {{- range $key, $value := .Values.extraArgs }}

--- a/charts/prometheus-openziti-exporter/values.yaml
+++ b/charts/prometheus-openziti-exporter/values.yaml
@@ -38,7 +38,7 @@ customLabels: {}
 securityContext: {}
 
 # Additional Environment variables
-env: 
+env:
 - name: ZITI_MGMT_API
   value: "https://localhost:1281"
 - name: ZITI_ADMIN_PASSWORD


### PR DESCRIPTION
#### What this PR does / why we need it
Default image tag is missing in prometheus-openziti-exporter deployment.
Setting it to `.Chart.AppVersion`

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/enthus-it/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-openziti-exporter]`)
