### PR TITLE
prometheus-openziti-exporter: Update to v0.0.5

### DIFF
--- a/charts/prometheus-openziti-exporter/Chart.yaml
+++ b/charts/prometheus-openziti-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.0.4
+appVersion: v0.0.5
 description: Prometheus exporter for Openziti
 name: prometheus-openziti-exporter
-version: 1.0.4
+version: 1.0.5
 icon: https://openziti.io/img/ziti-logo-dark.svg
 home: https://github.com/enthus-it/openziti_exporter
 sources:


### PR DESCRIPTION
#### What this PR does / why we need it
Update to the latest openziti_exporter version `0.0.5`
