### PR TITLE
[prometheus-openziti-exporter] Update openziti_exporter to v0.0.10

### DIFF
--- a/charts/prometheus-openziti-exporter/Chart.yaml
+++ b/charts/prometheus-openziti-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.0.9
+appVersion: v0.0.10
 description: Prometheus exporter for Openziti
 name: prometheus-openziti-exporter
-version: 1.0.10
+version: 1.0.11
 icon: https://openziti.io/img/ziti-logo-dark.svg
 home: https://github.com/enthus-it/openziti_exporter
 sources:

--- a/charts/prometheus-openziti-exporter/README.md
+++ b/charts/prometheus-openziti-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-openziti-exporter
 
-![Version: 1.0.10](https://img.shields.io/badge/Version-1.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.9](https://img.shields.io/badge/AppVersion-v0.0.9-informational?style=flat-square)
+![Version: 1.0.11](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.10](https://img.shields.io/badge/AppVersion-v0.0.10-informational?style=flat-square)
 
 Prometheus exporter for Openziti
 

--- a/charts/prometheus-openziti-exporter/values.yaml
+++ b/charts/prometheus-openziti-exporter/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   registry: ghcr.io
-  repository: enthus-it/openziti_exporter
+  repository: enthus-it/openziti-exporter
   # Overrides the image tag whose default is {{ printf "v%s" .Chart.AppVersion }}
   tag: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Update Update openziti_exporter to v0.0.10

#### Which issue this PR fixes

With this version, there are multi-arch images.
Image name changed from `ghcr.io/enthus-it/openziti_exporter` to `ghcr.io/enthus-it/openziti-exporter`

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/enthus-it/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-openziti-exporter]`)
